### PR TITLE
fix D12 rolling as D20

### DIFF
--- a/Menubar D20/DiceRollerViewController.swift
+++ b/Menubar D20/DiceRollerViewController.swift
@@ -112,7 +112,7 @@ class DiceRollerViewController: NSViewController {
                 currentNumberOfSides = 8
             case "d10":
                 currentNumberOfSides = 10
-            case "d10":
+            case "d12":
                 currentNumberOfSides = 12
             case "d20":
                 currentNumberOfSides = 20


### PR DESCRIPTION
There appears to be a small mistake here in this case statement causing the D12 selection to roll as D20 due to fall through. This should fix it, but I honestly don't have Xcode 7 or 10.11 right now to test the build.
